### PR TITLE
Fixed links to BrickLink

### DIFF
--- a/mariocodes.html
+++ b/mariocodes.html
@@ -135,7 +135,7 @@ var database_data = {
       "label": "START",
       "blpns": [
         {
-          "blpn": "3068bpb1380",
+          "blpn": "3068pb1380",
           "name": "Start (Mario starter set)"
         },
         {
@@ -150,7 +150,7 @@ var database_data = {
       "label": "START2",
       "blpns": [
         {
-          "blpn": "3068bpb1802",
+          "blpn": "3068pb1802",
           "name": "Start 60 (Luigi)"
         }
       ],
@@ -161,7 +161,7 @@ var database_data = {
       "label": "START3",
       "blpns": [
         {
-          "blpn": "3068bpb2093",
+          "blpn": "3068pb2093",
           "name": "Start 60 (Peach)"
         }
       ],
@@ -172,7 +172,7 @@ var database_data = {
       "label": "START 30",
       "blpns": [
         {
-          "blpn": "3068bpb1483",
+          "blpn": "3068pb1483",
           "name": "Start 30"
         }
       ],
@@ -183,7 +183,7 @@ var database_data = {
       "label": "STARTC50",
       "blpns": [
         {
-          "blpn": "3068bpb1954",
+          "blpn": "3068pb1954",
           "name": "50-coin Start"
         }
       ],
@@ -194,7 +194,7 @@ var database_data = {
       "label": "START 80",
       "blpns": [
         {
-          "blpn": "3068bpb2060",
+          "blpn": "3068pb2060",
           "name": "Peach castle start"
         }
       ]
@@ -204,7 +204,7 @@ var database_data = {
       "label": "START 90",
       "blpns": [
         {
-          "blpn": "3068bpb1962",
+          "blpn": "3068pb1962",
           "name": "Cannon Start 90"
         }
       ],
@@ -215,7 +215,7 @@ var database_data = {
       "label": "SSTART90",
       "blpns": [
         {
-          "blpn": "3068bpb1972",
+          "blpn": "3068pb1972",
           "name": "Spooky Start 90"
         }
       ],
@@ -226,7 +226,7 @@ var database_data = {
       "label": "CHKPOINT",
       "blpns": [
         {
-          "blpn": "3068bpb2153",
+          "blpn": "3068pb2153",
           "name": "Checkpoint flag"
         }
       ],
@@ -298,7 +298,7 @@ var database_data = {
       "label": "CAMPFIRE",
       "blpns": [
         {
-          "blpn": "3068bpb2186",
+          "blpn": "3068pb2186",
           "name": "Campfire"
         }
       ]
@@ -308,7 +308,7 @@ var database_data = {
       "label": "YOSHI",
       "blpns": [
         {
-          "blpn": "3068bpb1385",
+          "blpn": "3068pb1385",
           "name": "Speech Bubble Yoshi"
         }
       ]
@@ -318,11 +318,11 @@ var database_data = {
       "label": "TOAD",
       "blpns": [
         {
-          "blpn": "3068bpb1402",
+          "blpn": "3068pb1402",
           "name": "Speech Bubble Toad"
         },
         {
-          "blpn": "3068bpb2053",
+          "blpn": "3068pb2053",
           "name": "Green, Purple, Blue & Yellow Toad / Toadette Speech Bubble"
         }
       ]
@@ -332,7 +332,7 @@ var database_data = {
       "label": "TOADETTE",
       "blpns": [
         {
-          "blpn": "3068bpb1401",
+          "blpn": "3068pb1401",
           "name": "Speech Bubble Toadette"
         }
       ]
@@ -342,7 +342,7 @@ var database_data = {
       "label": "TOAD 2",
       "blpns": [
         {
-          "blpn": "3068bpb1957",
+          "blpn": "3068pb1957",
           "name": "Blue Toad"
         }
       ],
@@ -353,7 +353,7 @@ var database_data = {
       "label": "PENGUIN",
       "blpns": [
         {
-          "blpn": "3068bpb2333",
+          "blpn": "3068pb2333",
           "name": "Penguin"
         },
         {
@@ -368,7 +368,7 @@ var database_data = {
       "label": "DONKEY K",
       "blpns": [
         {
-          "blpn": "3068bpb2291",
+          "blpn": "3068pb2291",
           "name": "Donkey Kong"
         }
       ],
@@ -379,7 +379,7 @@ var database_data = {
       "label": "CRANKY K",
       "blpns": [
         {
-          "blpn": "3068bpb2289",
+          "blpn": "3068pb2289",
           "name": "Cranky Kong"
         }
       ],
@@ -390,7 +390,7 @@ var database_data = {
       "label": "DIDDY K",
       "blpns": [
         {
-          "blpn": "3068bpb2307",
+          "blpn": "3068pb2307",
           "name": "Diddy Kong"
         }
       ],
@@ -401,7 +401,7 @@ var database_data = {
       "label": "FUNKY K",
       "blpns": [
         {
-          "blpn": "3068bpb2310",
+          "blpn": "3068pb2310",
           "name": "Funky Kong"
         }
       ],
@@ -412,7 +412,7 @@ var database_data = {
       "label": "DORRIE",
       "blpns": [
         {
-          "blpn": "3068bpb1985",
+          "blpn": "3068pb1985",
           "name": "Dorrie"
         }
       ]
@@ -422,7 +422,7 @@ var database_data = {
       "label": "DORRIE2",
       "blpns": [
         {
-          "blpn": "3068bpb2341",
+          "blpn": "3068pb2341",
           "name": "Dorrie the Dolphin"
         },
         {
@@ -437,7 +437,7 @@ var database_data = {
       "label": "DOLPHIN",
       "blpns": [
         {
-          "blpn": "3068bpb1979",
+          "blpn": "3068pb1979",
           "name": "Dolphin"
         }
       ],
@@ -459,7 +459,7 @@ var database_data = {
       "label": "MINECART",
       "blpns": [
         {
-          "blpn": "3068bpb2311",
+          "blpn": "3068pb2311",
           "name": "Minecart"
         }
       ],
@@ -470,7 +470,7 @@ var database_data = {
       "label": "DK RIDE",
       "blpns": [
         {
-          "blpn": "3068bpb2290",
+          "blpn": "3068pb2290",
           "name": "Donkey Kong ride"
         }
       ]
@@ -480,7 +480,7 @@ var database_data = {
       "label": "BWSRKART",
       "blpns": [
         {
-          "blpn": "3068bpb2334",
+          "blpn": "3068pb2334",
           "name": "Bowser's Car and Mario Kart music"
         },
         {
@@ -494,7 +494,7 @@ var database_data = {
       "label": "BABYOSHI",
       "blpns": [
         {
-          "blpn": "3068bpb2064",
+          "blpn": "3068pb2064",
           "name": "Chubby Baby Yoshi, yellow"
         }
       ]
@@ -514,7 +514,7 @@ var database_data = {
       "label": "YOSHIEGG",
       "blpns": [
         {
-          "blpn": "3068bpb1807",
+          "blpn": "3068pb1807",
           "name": "Pink Yoshi egg"
         },
         {
@@ -529,7 +529,7 @@ var database_data = {
       "label": "YOSHI E2",
       "blpns": [
         {
-          "blpn": "3068bpb1977",
+          "blpn": "3068pb1977",
           "name": "Yellow Yoshi egg"
         }
       ]
@@ -539,7 +539,7 @@ var database_data = {
       "label": "YOSHI E3",
       "blpns": [
         {
-          "blpn": "3068bpb2065",
+          "blpn": "3068pb2065",
           "name": "Red Yoshi egg"
         }
       ]
@@ -549,7 +549,7 @@ var database_data = {
       "label": "YOSHI E4",
       "blpns": [
         {
-          "blpn": "3068bpb2072",
+          "blpn": "3068pb2072",
           "name": "Green Yoshi egg"
         }
       ]
@@ -559,7 +559,7 @@ var database_data = {
       "label": "YOSHI E5",
       "blpns": [
         {
-          "blpn": "3068bpb2154",
+          "blpn": "3068pb2154",
           "name": "Blue Yoshi egg"
         }
       ]
@@ -569,7 +569,7 @@ var database_data = {
       "label": "YOSHIEGG",
       "blpns": [
         {
-          "blpn": "3068bpb2335",
+          "blpn": "3068pb2335",
           "name": "Hatching Yoshi Egg"
         },
         {
@@ -584,7 +584,7 @@ var database_data = {
       "label": "POLTER",
       "blpns": [
         {
-          "blpn": "3068bpb1983",
+          "blpn": "3068pb1983",
           "name": "Polterpup"
         }
       ]
@@ -594,7 +594,7 @@ var database_data = {
       "label": "GOLDBONE",
       "blpns": [
         {
-          "blpn": "3068bpb1981",
+          "blpn": "3068pb1981",
           "name": "Golden bone"
         }
       ],
@@ -605,7 +605,7 @@ var database_data = {
       "label": "EGADD",
       "blpns": [
         {
-          "blpn": "3068bpb1986",
+          "blpn": "3068pb1986",
           "name": "Professor E. Gadd"
         }
       ]
@@ -615,7 +615,7 @@ var database_data = {
       "label": "BPENGUIN",
       "blpns": [
         {
-          "blpn": "3068bpb1909",
+          "blpn": "3068pb1909",
           "name": "Baby penguin"
         }
       ]
@@ -625,7 +625,7 @@ var database_data = {
       "label": "NABBIT",
       "blpns": [
         {
-          "blpn": "3068bpb2063",
+          "blpn": "3068pb2063",
           "name": "Nabbit"
         }
       ],
@@ -647,7 +647,7 @@ var database_data = {
       "label": "1 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1404",
+          "blpn": "3068pb1404",
           "name": "1 Block Treasure"
         }
       ]
@@ -657,7 +657,7 @@ var database_data = {
       "label": "2 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1405",
+          "blpn": "3068pb1405",
           "name": "2 Block Treasure"
         }
       ]
@@ -667,7 +667,7 @@ var database_data = {
       "label": "3 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1406",
+          "blpn": "3068pb1406",
           "name": "3 Block Treasure"
         }
       ]
@@ -677,7 +677,7 @@ var database_data = {
       "label": "GEM PURP",
       "blpns": [
         {
-          "blpn": "3068bpb1968",
+          "blpn": "3068pb1968",
           "name": "Purple diamond"
         }
       ]
@@ -687,7 +687,7 @@ var database_data = {
       "label": "GEM BLUE",
       "blpns": [
         {
-          "blpn": "3068bpb1967",
+          "blpn": "3068pb1967",
           "name": "Blue diamond"
         }
       ]
@@ -697,7 +697,7 @@ var database_data = {
       "label": "GEM GREE",
       "blpns": [
         {
-          "blpn": "3068bpb1969",
+          "blpn": "3068pb1969",
           "name": "Green diamond"
         }
       ]
@@ -707,7 +707,7 @@ var database_data = {
       "label": "CHEST",
       "blpns": [
         {
-          "blpn": "3068bpb2300",
+          "blpn": "3068pb2300",
           "name": "Locked Chest"
         }
       ],
@@ -718,7 +718,7 @@ var database_data = {
       "label": "CHESTKEY",
       "blpns": [
         {
-          "blpn": "3068bpb2301",
+          "blpn": "3068pb2301",
           "name": "Chest Key"
         }
       ]
@@ -728,11 +728,11 @@ var database_data = {
       "label": "RED C1",
       "blpns": [
         {
-          "blpn": "3068bpb1485",
+          "blpn": "3068pb1485",
           "name": "Red Coin Block Rounded (green tile)"
         },
         {
-          "blpn": "3068bpb1970",
+          "blpn": "3068pb1970",
           "name": "Red Coin Block Rounded"
         }
       ]
@@ -742,7 +742,7 @@ var database_data = {
       "label": "RED C2",
       "blpns": [
         {
-          "blpn": "3068bpb1487",
+          "blpn": "3068pb1487",
           "name": "Red Coin Block Triange (green tile)"
         },
         {
@@ -756,11 +756,11 @@ var database_data = {
       "label": "RED C3",
       "blpns": [
         {
-          "blpn": "3068bpb1486",
+          "blpn": "3068pb1486",
           "name": "Red Coin Block Square (green tile)"
         },
         {
-          "blpn": "3068bpb1971",
+          "blpn": "3068pb1971",
           "name": "Red Coin Block Square"
         }
       ]
@@ -770,7 +770,7 @@ var database_data = {
       "label": "GOLDGROW",
       "blpns": [
         {
-          "blpn": "3068bpb2071",
+          "blpn": "3068pb2071",
           "name": "Treat Carousel"
         }
       ],
@@ -781,7 +781,7 @@ var database_data = {
       "label": "PRESENT",
       "blpns": [
         {
-          "blpn": "3068bpb2095",
+          "blpn": "3068pb2095",
           "name": "Gift box 1"
         }
       ]
@@ -791,7 +791,7 @@ var database_data = {
       "label": "PRESENT2",
       "blpns": [
         {
-          "blpn": "3068bpb2070",
+          "blpn": "3068pb2070",
           "name": "Gift box 2"
         }
       ],
@@ -802,7 +802,7 @@ var database_data = {
       "label": "PRESENT3",
       "blpns": [
         {
-          "blpn": "3068bpb2152",
+          "blpn": "3068pb2152",
           "name": "Gift box 3"
         }
       ],
@@ -824,7 +824,7 @@ var database_data = {
       "label": "TURNIP",
       "blpns": [
         {
-          "blpn": "3068bpb2149",
+          "blpn": "3068pb2149",
           "name": "Turnip"
         }
       ],
@@ -901,7 +901,7 @@ var database_data = {
       "label": "PICNIC",
       "blpns": [
         {
-          "blpn": "3068bpb2284",
+          "blpn": "3068pb2284",
           "name": "Picnic Basket"
         }
       ],
@@ -912,7 +912,7 @@ var database_data = {
       "label": "PICNIC2",
       "blpns": [
         {
-          "blpn": "3068bpb2313",
+          "blpn": "3068pb2313",
           "name": "Picnic basket 2"
         },
         {
@@ -959,7 +959,7 @@ var database_data = {
       "label": "POW",
       "blpns": [
         {
-          "blpn": "3068bpb1361",
+          "blpn": "3068pb1361",
           "name": "POW"
         }
       ]
@@ -979,7 +979,7 @@ var database_data = {
       "label": "STAR",
       "blpns": [
         {
-          "blpn": "3068bpb1384",
+          "blpn": "3068pb1384",
           "name": "Star"
         }
       ]
@@ -989,7 +989,7 @@ var database_data = {
       "label": "TIMER",
       "blpns": [
         {
-          "blpn": "3068bpb1347",
+          "blpn": "3068pb1347",
           "name": "Timer"
         }
       ],
@@ -1000,7 +1000,7 @@ var database_data = {
       "label": "TIMER 2",
       "blpns": [
         {
-          "blpn": "3068bpb1855",
+          "blpn": "3068pb1855",
           "name": "Timer 2"
         }
       ],
@@ -1011,7 +1011,7 @@ var database_data = {
       "label": "TIMER 3",
       "blpns": [
         {
-          "blpn": "3068bpb2083",
+          "blpn": "3068pb2083",
           "name": "Timer 3"
         }
       ],
@@ -1022,7 +1022,7 @@ var database_data = {
       "label": "? BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1359",
+          "blpn": "3068pb1359",
           "name": "Mystery Block ?"
         }
       ]
@@ -1032,7 +1032,7 @@ var database_data = {
       "label": "P?BLOCK1",
       "blpns": [
         {
-          "blpn": "3068bpb1762",
+          "blpn": "3068pb1762",
           "name": "Customization Mystery Block 1"
         }
       ],
@@ -1044,7 +1044,7 @@ var database_data = {
       "label": "P?BLOCK2",
       "blpns": [
         {
-          "blpn": "3068bpb1784",
+          "blpn": "3068pb1784",
           "name": "Customization Mystery Block 2"
         }
       ],
@@ -1056,7 +1056,7 @@ var database_data = {
       "label": "TIMEGEAR",
       "blpns": [
         {
-          "blpn": "3068bpb1533",
+          "blpn": "3068pb1533",
           "name": "Customization Time Block"
         }
       ],
@@ -1067,7 +1067,7 @@ var database_data = {
       "label": "P SWITCH",
       "blpns": [
         {
-          "blpn": "3068bpb1394",
+          "blpn": "3068pb1394",
           "name": "P Switch"
         }
       ]
@@ -1077,7 +1077,7 @@ var database_data = {
       "label": "COIN 1",
       "blpns": [
         {
-          "blpn": "3068bpb1387",
+          "blpn": "3068pb1387",
           "name": "Coin"
         },
         {
@@ -1091,7 +1091,7 @@ var database_data = {
       "label": "COIN 2",
       "blpns": [
         {
-          "blpn": "3068bpb1393",
+          "blpn": "3068pb1393",
           "name": "Coin 2"
         }
       ]
@@ -1101,11 +1101,11 @@ var database_data = {
       "label": "COIN 3",
       "blpns": [
         {
-          "blpn": "3068bpb1527",
+          "blpn": "3068pb1527",
           "name": "Coin 3"
         },
         {
-          "blpn": "3068bpb2079",
+          "blpn": "3068pb2079",
           "name": "Coin 3"
         }
       ]
@@ -1183,7 +1183,7 @@ var database_data = {
           "name": "Peepa"
         },
         {
-          "blpn": "3068bpb1409",
+          "blpn": "3068pb1409",
           "name": "Boo"
         }
       ],
@@ -1194,7 +1194,7 @@ var database_data = {
       "label": "BOO",
       "blpns": [
         {
-          "blpn": "3068bpb1799",
+          "blpn": "3068pb1799",
           "name": "Boo"
         }
       ]
@@ -1204,7 +1204,7 @@ var database_data = {
       "label": "GRBG GHO",
       "blpns": [
         {
-          "blpn": "3068bpb1973",
+          "blpn": "3068pb1973",
           "name": "Garbage can ghost"
         }
       ],
@@ -1215,7 +1215,7 @@ var database_data = {
       "label": "GRBGHOST",
       "blpns": [
         {
-          "blpn": "3068bpb1974",
+          "blpn": "3068pb1974",
           "name": "Grabbing ghost"
         }
       ],
@@ -1237,7 +1237,7 @@ var database_data = {
       "label": "BOGMIRE",
       "blpns": [
         {
-          "blpn": "3068bpb1984",
+          "blpn": "3068pb1984",
           "name": "Bogmire"
         }
       ],
@@ -1262,23 +1262,23 @@ var database_data = {
       "label": "GOOMBA",
       "blpns": [
         {
-          "blpn": "3068bpb1381",
+          "blpn": "3068pb1381",
           "name": "Goomba"
         },
         {
-          "blpn": "3068bpb1505",
+          "blpn": "3068pb1505",
           "name": "Bone Goomba"
         },
         {
-          "blpn": "3068bpb1501",
+          "blpn": "3068pb1501",
           "name": "Ninji"
         },
         {
-          "blpn": "3068bpb1348",
+          "blpn": "3068pb1348",
           "name": "Bullet Bill"
         },
         {
-          "blpn": "3068bpb1360",
+          "blpn": "3068pb1360",
           "name": "Monty Mole"
         },
         {
@@ -1286,31 +1286,31 @@ var database_data = {
           "name": "Fly Guy"
         },
         {
-          "blpn": "3068bpb1365",
+          "blpn": "3068pb1365",
           "name": "Fuzzy"
         },
         {
-          "blpn": "3068bpb1520",
+          "blpn": "3068pb1520",
           "name": "Foo"
         },
         {
-          "blpn": "3068bpb1904",
+          "blpn": "3068pb1904",
           "name": "Crowber"
         },
         {
-          "blpn": "3068bpb1915",
+          "blpn": "3068pb1915",
           "name": "Para-Biddybud"
         },
         {
-          "blpn": "3068bpb1499",
+          "blpn": "3068pb1499",
           "name": "Parachute Goomba"
         },
         {
-          "blpn": "3068bpb1916",
+          "blpn": "3068pb1916",
           "name": "Scaredy Rat"
         },
         {
-          "blpn": "3068bpb2096",
+          "blpn": "3068pb2096",
           "name": "Cat Goomba"
         },
         {
@@ -1318,35 +1318,35 @@ var database_data = {
           "name": "Shy Guy"
         },
         {
-          "blpn": "3068bpb2054",
+          "blpn": "3068pb2054",
           "name": "Toady"
         },
         {
-          "blpn": "3068bpb1798",
+          "blpn": "3068pb1798",
           "name": "Swoop"
         },
         {
-          "blpn": "3068bpb1932",
+          "blpn": "3068pb1932",
           "name": "Stingby"
         },
         {
-          "blpn": "3068bpb1905",
+          "blpn": "3068pb1905",
           "name": "Galoomba"
         },
         {
-          "blpn": "3068bpb1888",
+          "blpn": "3068pb1888",
           "name": "Goombrat"
         },
         {
-          "blpn": "3068bpb1908",
+          "blpn": "3068pb1908",
           "name": "Ant Trooper"
         },
         {
-          "blpn": "3068bpb2062",
+          "blpn": "3068pb2062",
           "name": "Waddlewing"
         },
         {
-          "blpn": "3068bpb1797",
+          "blpn": "3068pb1797",
           "name": "Scuttlebug"
         },
         {
@@ -1360,7 +1360,7 @@ var database_data = {
       "label": "THWIMP",
       "blpns": [
         {
-          "blpn": "3068bpb1524",
+          "blpn": "3068pb1524",
           "name": "Thwimp"
         }
       ]
@@ -1370,7 +1370,7 @@ var database_data = {
       "label": "BRAMBALL",
       "blpns": [
         {
-          "blpn": "3068bpb1526",
+          "blpn": "3068pb1526",
           "name": "Bramball"
         }
       ]
@@ -1380,31 +1380,31 @@ var database_data = {
       "label": "BLOOPER",
       "blpns": [
         {
-          "blpn": "3068bpb1363",
+          "blpn": "3068pb1363",
           "name": "Blooper"
         },
         {
-          "blpn": "3068bpb1413",
+          "blpn": "3068pb1413",
           "name": "Urchin"
         },
         {
-          "blpn": "3068bpb1403",
+          "blpn": "3068pb1403",
           "name": "Cheep Cheep"
         },
         {
-          "blpn": "3068bpb1349",
+          "blpn": "3068pb1349",
           "name": "Eep Cheep"
         },
         {
-          "blpn": "3068bpb1500",
+          "blpn": "3068pb1500",
           "name": "Huckit Crab"
         },
         {
-          "blpn": "3068bpb1521",
+          "blpn": "3068pb1521",
           "name": "Spiny Cheep Cheep"
         },
         {
-          "blpn": "3068bpb1796",
+          "blpn": "3068pb1796",
           "name": "Torpedo Ted"
         }
       ]
@@ -1414,23 +1414,23 @@ var database_data = {
       "label": "BUZZY",
       "blpns": [
         {
-          "blpn": "3068bpb1519",
+          "blpn": "3068pb1519",
           "name": "Para-Beetle"
         },
         {
-          "blpn": "3068bpb1415",
+          "blpn": "3068pb1415",
           "name": "Buzzy Beetle"
         },
         {
-          "blpn": "3068bpb1364",
+          "blpn": "3068pb1364",
           "name": "Spiny"
         },
         {
-          "blpn": "3068bpb1964",
+          "blpn": "3068pb1964",
           "name": "Mechakoopa"
         },
         {
-          "blpn": "3068bpb1907",
+          "blpn": "3068pb1907",
           "name": "Bony Beetle"
         },
         {
@@ -1454,15 +1454,15 @@ var database_data = {
       "label": "DRY BONE",
       "blpns": [
         {
-          "blpn": "3068bpb1408",
+          "blpn": "3068pb1408",
           "name": "Dry Bones"
         },
         {
-          "blpn": "3068bpb1414",
+          "blpn": "3068pb1414",
           "name": "Paragoomba"
         },
         {
-          "blpn": "3068bpb1397",
+          "blpn": "3068pb1397",
           "name": "Lava Bubble"
         },
         {
@@ -1476,7 +1476,7 @@ var database_data = {
       "label": "AMP",
       "blpns": [
         {
-          "blpn": "3068bpb1801",
+          "blpn": "3068pb1801",
           "name": "Amp"
         }
       ],
@@ -1487,7 +1487,7 @@ var database_data = {
       "label": "FREEZIE",
       "blpns": [
         {
-          "blpn": "3068bpb1914",
+          "blpn": "3068pb1914",
           "name": "Freezie"
         }
       ],
@@ -1498,7 +1498,7 @@ var database_data = {
       "label": "WHOMP",
       "blpns": [
         {
-          "blpn": "3068bpb1396",
+          "blpn": "3068pb1396",
           "name": "Whomp"
         }
       ],
@@ -1509,7 +1509,7 @@ var database_data = {
       "label": "LAVA",
       "blpns": [
         {
-          "blpn": "3068bpb1410",
+          "blpn": "3068pb1410",
           "name": "Lava Bubble"
         },
         {
@@ -1523,7 +1523,7 @@ var database_data = {
       "label": "THWOMP",
       "blpns": [
         {
-          "blpn": "3068bpb1407",
+          "blpn": "3068pb1407",
           "name": "Thwomp"
         },
         {
@@ -1537,7 +1537,7 @@ var database_data = {
       "label": "BOB-OMB",
       "blpns": [
         {
-          "blpn": "3068bpb1476",
+          "blpn": "3068pb1476",
           "name": "Bob-Omb 1"
         }
       ]
@@ -1547,7 +1547,7 @@ var database_data = {
       "label": "BOMB 2",
       "blpns": [
         {
-          "blpn": "3068bpb1366",
+          "blpn": "3068pb1366",
           "name": "Bob-Omb 2"
         }
       ]
@@ -1557,7 +1557,7 @@ var database_data = {
       "label": "BOMB 3",
       "blpns": [
         {
-          "blpn": "3068bpb1883",
+          "blpn": "3068pb1883",
           "name": "Bob-omb"
         },
         {
@@ -1571,7 +1571,7 @@ var database_data = {
       "label": "PARABOMB",
       "blpns": [
         {
-          "blpn": "3068bpb1795",
+          "blpn": "3068pb1795",
           "name": "Parachute Bob-omb"
         }
       ]
@@ -1581,11 +1581,11 @@ var database_data = {
       "label": "PIRANHA",
       "blpns": [
         {
-          "blpn": "3068bpb1382",
+          "blpn": "3068pb1382",
           "name": "Piranha Plant"
         },
         {
-          "blpn": "3068bpb2299",
+          "blpn": "3068pb2299",
           "name": "Bone Piranha Plant"
         },
         {
@@ -1599,7 +1599,7 @@ var database_data = {
       "label": "KOOPA 1",
       "blpns": [
         {
-          "blpn": "3068bpb1383",
+          "blpn": "3068pb1383",
           "name": "Koopa Troopa"
         }
       ]
@@ -1609,7 +1609,7 @@ var database_data = {
       "label": "KOOPA 2",
       "blpns": [
         {
-          "blpn": "3068bpb1351",
+          "blpn": "3068pb1351",
           "name": "Koopa Troopa 2"
         }
       ]
@@ -1619,7 +1619,7 @@ var database_data = {
       "label": "KPARAT 1",
       "blpns": [
         {
-          "blpn": "3068bpb1477",
+          "blpn": "3068pb1477",
           "name": "Koopa Paratroopa"
         }
       ]
@@ -1629,7 +1629,7 @@ var database_data = {
       "label": "KPARAT 2",
       "blpns": [
         {
-          "blpn": "3068bpb1478",
+          "blpn": "3068pb1478",
           "name": "Koopa Paratroopa 2"
         }
       ]
@@ -1639,7 +1639,7 @@ var database_data = {
       "label": "EXPLODE",
       "blpns": [
         {
-          "blpn": "3068bpb1386",
+          "blpn": "3068pb1386",
           "name": "Swoop Explosion"
         }
       ]
@@ -1660,7 +1660,7 @@ var database_data = {
       "label": "STONE",
       "blpns": [
         {
-          "blpn": "3068bpb1362",
+          "blpn": "3068pb1362",
           "name": "Stone Eye"
         }
       ]
@@ -1670,7 +1670,7 @@ var database_data = {
       "label": "POKEY",
       "blpns": [
         {
-          "blpn": "3068bpb1369",
+          "blpn": "3068pb1369",
           "name": "Pokey"
         }
       ],
@@ -1681,7 +1681,7 @@ var database_data = {
       "label": "BIG URCH",
       "blpns": [
         {
-          "blpn": "3068bpb1978",
+          "blpn": "3068pb1978",
           "name": "Purple Urchin"
         }
       ],
@@ -1692,7 +1692,7 @@ var database_data = {
       "label": "BULLY",
       "blpns": [
         {
-          "blpn": "3068bpb1910",
+          "blpn": "3068pb1910",
           "name": "Bully"
         }
       ],
@@ -1703,7 +1703,7 @@ var database_data = {
       "label": "CONKDOR",
       "blpns": [
         {
-          "blpn": "3068bpb2125",
+          "blpn": "3068pb2125",
           "name": "Conkdor"
         }
       ],
@@ -1714,7 +1714,7 @@ var database_data = {
       "label": "LAKITU",
       "blpns": [
         {
-          "blpn": "3068bpb1856",
+          "blpn": "3068pb1856",
           "name": "Lakitu"
         },
         {
@@ -1729,7 +1729,7 @@ var database_data = {
       "label": "ROCKY",
       "blpns": [
         {
-          "blpn": "3068bpb1959",
+          "blpn": "3068pb1959",
           "name": "Rocky Wrench"
         }
       ],
@@ -1740,7 +1740,7 @@ var database_data = {
       "label": "COINCOFF",
       "blpns": [
         {
-          "blpn": "3068bpb1911",
+          "blpn": "3068pb1911",
           "name": "Coin Coffer"
         }
       ],
@@ -1751,11 +1751,11 @@ var database_data = {
       "label": "GRRROL",
       "blpns": [
         {
-          "blpn": "3068bpb1955",
+          "blpn": "3068pb1955",
           "name": "Grrrol"
         },
         {
-          "blpn": "3068bpb2075",
+          "blpn": "3068pb2075",
           "name": "Piranha Plant"
         }
       ],
@@ -1766,7 +1766,7 @@ var database_data = {
       "label": "BIG GOOM",
       "blpns": [
         {
-          "blpn": "3068bpb2076",
+          "blpn": "3068pb2076",
           "name": "Big Goomba"
         }
       ],
@@ -1777,7 +1777,7 @@ var database_data = {
       "label": "BIGKOOPA",
       "blpns": [
         {
-          "blpn": "3068bpb2078",
+          "blpn": "3068pb2078",
           "name": "Big Koopa"
         }
       ],
@@ -1788,7 +1788,7 @@ var database_data = {
       "label": "FLIPRUS",
       "blpns": [
         {
-          "blpn": "3068bpb2185",
+          "blpn": "3068pb2185",
           "name": "Fliprus"
         }
       ],
@@ -1799,7 +1799,7 @@ var database_data = {
       "label": "BOOMRBRO",
       "blpns": [
         {
-          "blpn": "3068bpb2073",
+          "blpn": "3068pb2073",
           "name": "Boomerang Bro"
         }
       ],
@@ -1810,15 +1810,15 @@ var database_data = {
       "label": "HAMMRBRO",
       "blpns": [
         {
-          "blpn": "3068bpb2055",
+          "blpn": "3068pb2055",
           "name": "Hammer Bro"
         },
         {
-          "blpn": "3068bpb2177",
+          "blpn": "3068pb2177",
           "name": "Ice Bro"
         },
         {
-          "blpn": "3068bpb2159",
+          "blpn": "3068pb2159",
           "name": "Fire Bro"
         }
       ],
@@ -1840,7 +1840,7 @@ var database_data = {
       "label": "BIGSPIKE",
       "blpns": [
         {
-          "blpn": "3068bpb2074",
+          "blpn": "3068pb2074",
           "name": "Big Spike"
         }
       ],
@@ -1851,7 +1851,7 @@ var database_data = {
       "label": "SMOLSUMO",
       "blpns": [
         {
-          "blpn": "3068bpb2176",
+          "blpn": "3068pb2176",
           "name": "Sumo Bro"
         }
       ],
@@ -1862,7 +1862,7 @@ var database_data = {
       "label": "REZNOR 1",
       "blpns": [
         {
-          "blpn": "3068bpb1885",
+          "blpn": "3068pb1885",
           "name": "Reznor (With fireball)"
         }
       ],
@@ -1873,7 +1873,7 @@ var database_data = {
       "label": "REZNOR 2",
       "blpns": [
         {
-          "blpn": "3068bpb1884",
+          "blpn": "3068pb1884",
           "name": "Reznor (No fireball)"
         }
       ],
@@ -1884,7 +1884,7 @@ var database_data = {
       "label": "SUMO",
       "blpns": [
         {
-          "blpn": "3068bpb1844",
+          "blpn": "3068pb1844",
           "name": "Boss Sumo"
         }
       ],
@@ -1895,7 +1895,7 @@ var database_data = {
       "label": "BOOMBOOM",
       "blpns": [
         {
-          "blpn": "3068bpb1814",
+          "blpn": "3068pb1814",
           "name": "Boom-boom"
         }
       ],
@@ -1906,7 +1906,7 @@ var database_data = {
       "label": "NES",
       "blpns": [
         {
-          "blpn": "3068bpb1390",
+          "blpn": "3068pb1390",
           "name": "TV"
         }
       ],
@@ -1930,7 +1930,7 @@ var database_data = {
       "label": "BIGBOWSR",
       "blpns": [
         {
-          "blpn": "3068bpb2113",
+          "blpn": "3068pb2113",
           "name": "Mighty Bowser"
         }
       ],
@@ -1941,7 +1941,7 @@ var database_data = {
       "label": "HAMMER",
       "blpns": [
         {
-          "blpn": "3068bpb1370",
+          "blpn": "3068pb1370",
           "name": "Hammer Turntable"
         }
       ]
@@ -2007,7 +2007,7 @@ var database_data = {
       "label": "SPIN 6",
       "blpns": [
         {
-          "blpn": "3068bpb1966",
+          "blpn": "3068pb1966",
           "name": "Spin 6"
         }
       ],
@@ -2022,7 +2022,7 @@ var database_data = {
           "name": "Side-to-side Waggle Arrows"
         },
         {
-          "blpn": "3068bpb2067",
+          "blpn": "3068pb2067",
           "name": "Biased Directional Arrows"
         }
       ],
@@ -2044,7 +2044,7 @@ var database_data = {
       "label": "SPINY",
       "blpns": [
         {
-          "blpn": "3068bpb1484",
+          "blpn": "3068pb1484",
           "name": "Spiny 2"
         }
       ]
@@ -2080,7 +2080,7 @@ var database_data = {
       "label": "BDARR 2",
       "blpns": [
         {
-          "blpn": "3068bpb1350",
+          "blpn": "3068pb1350",
           "name": "Bidirectional Arrows 2"
         }
       ],
@@ -2091,7 +2091,7 @@ var database_data = {
       "label": "BDARR 3",
       "blpns": [
         {
-          "blpn": "3068bpb1502",
+          "blpn": "3068pb1502",
           "name": "Bidirectional Arrows 3"
         }
       ],
@@ -2128,7 +2128,7 @@ var database_data = {
       "label": "LAVALIFT",
       "blpns": [
         {
-          "blpn": "3068bpb2160",
+          "blpn": "3068pb2160",
           "name": "Curved Bidirectional Arrows (Lava Lift)"
         }
       ],
@@ -2139,7 +2139,7 @@ var database_data = {
       "label": "KEYHOLE",
       "blpns": [
         {
-          "blpn": "3068bpb1982",
+          "blpn": "3068pb1982",
           "name": "Entrance keyhole"
         }
       ],
@@ -2180,7 +2180,7 @@ var database_data = {
       "label": "GEAR",
       "blpns": [
         {
-          "blpn": "3068bpb1803",
+          "blpn": "3068pb1803",
           "name": "Gear icon"
         }
       ],
@@ -2191,7 +2191,7 @@ var database_data = {
       "label": "NUT",
       "blpns": [
         {
-          "blpn": "3068bpb1804",
+          "blpn": "3068pb1804",
           "name": "Nut icon"
         }
       ],
@@ -2224,7 +2224,7 @@ var database_data = {
       "label": "SWING",
       "blpns": [
         {
-          "blpn": "3068bpb2094",
+          "blpn": "3068pb2094",
           "name": "Peach swing"
         }
       ],
@@ -2235,7 +2235,7 @@ var database_data = {
       "label": "BIASDIR",
       "blpns": [
         {
-          "blpn": "3068bpb1853",
+          "blpn": "3068pb1853",
           "name": "Biased directional Arrows"
         },
         {
@@ -2249,7 +2249,7 @@ var database_data = {
       "label": "STEERING",
       "blpns": [
         {
-          "blpn": "3068bpb1958",
+          "blpn": "3068pb1958",
           "name": "Steering wheel for Bowser, Larry, and Morton's ships.  Tip to fire cannon. Miltiplayer fire at each other."
         }
       ],
@@ -2286,7 +2286,7 @@ var database_data = {
       "label": "DIVING",
       "blpns": [
         {
-          "blpn": "3068bpb1980",
+          "blpn": "3068pb1980",
           "name": "Diving board"
         }
       ],
@@ -2297,7 +2297,7 @@ var database_data = {
       "label": "SNAGGLES",
       "blpns": [
         {
-          "blpn": "3068bpb2309",
+          "blpn": "3068pb2309",
           "name": "Snaggles the shark"
         }
       ],
@@ -2308,7 +2308,7 @@ var database_data = {
       "label": "CHECHOMP",
       "blpns": [
         {
-          "blpn": "3068bpb2340",
+          "blpn": "3068pb2340",
           "name": "Cheep Chomp"
         },
         {
@@ -2323,7 +2323,7 @@ var database_data = {
       "label": "EXERCISE",
       "blpns": [
         {
-          "blpn": "3068bpb2304",
+          "blpn": "3068pb2304",
           "name": "Barbells"
         }
       ],
@@ -2334,7 +2334,7 @@ var database_data = {
       "label": "PCTHRONE",
       "blpns": [
         {
-          "blpn": "3068bpb2066",
+          "blpn": "3068pb2066",
           "name": "Peach throne"
         },
         {
@@ -2349,7 +2349,7 @@ var database_data = {
       "label": "BROOM",
       "blpns": [
         {
-          "blpn": "3068bpb1961",
+          "blpn": "3068pb1961",
           "name": "Kamek Broom"
         }
       ],
@@ -2360,7 +2360,7 @@ var database_data = {
       "label": "CLOWN",
       "blpns": [
         {
-          "blpn": "3068bpb1918",
+          "blpn": "3068pb1918",
           "name": "Bowser Jr's Clown Car"
         }
       ],
@@ -2371,7 +2371,7 @@ var database_data = {
       "label": "SHOE",
       "blpns": [
         {
-          "blpn": "3068bpb2084",
+          "blpn": "3068pb2084",
           "name": "Kuribo's shoe"
         }
       ],
@@ -2393,7 +2393,7 @@ var database_data = {
       "label": "BALLOON",
       "blpns": [
         {
-          "blpn": "3068bpb2150",
+          "blpn": "3068pb2150",
           "name": "Peach's Balloon Ride"
         }
       ]
@@ -2423,7 +2423,7 @@ var database_data = {
       "label": "RAMBI",
       "blpns": [
         {
-          "blpn": "3068bpb2305",
+          "blpn": "3068pb2305",
           "name": "Rambi the Rhino"
         }
       ],
@@ -2434,7 +2434,7 @@ var database_data = {
       "label": "PLANE",
       "blpns": [
         {
-          "blpn": "3068bpb2308",
+          "blpn": "3068pb2308",
           "name": "Airplane"
         }
       ],
@@ -2456,7 +2456,7 @@ var database_data = {
       "label": "MUSIC",
       "blpns": [
         {
-          "blpn": "3068bpb2296",
+          "blpn": "3068pb2296",
           "name": "Donkey Kong dancing"
         }
       ],
@@ -2467,7 +2467,7 @@ var database_data = {
       "label": "BONGOS",
       "blpns": [
         {
-          "blpn": "3068bpb2292",
+          "blpn": "3068pb2292",
           "name": "Bongo music"
         }
       ],
@@ -2500,7 +2500,7 @@ var database_data = {
       "label": "BIRDO",
       "blpns": [
         {
-          "blpn": "3068bpb2178",
+          "blpn": "3068pb2178",
           "name": "Birdo egg"
         }
       ],
@@ -2511,7 +2511,7 @@ var database_data = {
       "label": "MAST",
       "blpns": [
         {
-          "blpn": "3068bpb1960",
+          "blpn": "3068pb1960",
           "name": "Bowser ship mast"
         }
       ],
@@ -2544,7 +2544,7 @@ var database_data = {
       "label": "LARRY",
       "blpns": [
         {
-          "blpn": "3068bpb1534",
+          "blpn": "3068pb1534",
           "name": "Larry"
         }
       ],
@@ -2555,7 +2555,7 @@ var database_data = {
       "label": "LUDWIG",
       "blpns": [
         {
-          "blpn": "3068bpb2058",
+          "blpn": "3068pb2058",
           "name": "Ludwig von Koopa"
         }
       ],
@@ -2577,7 +2577,7 @@ var database_data = {
       "label": "IGGY",
       "blpns": [
         {
-          "blpn": "3068bpb2077",
+          "blpn": "3068pb2077",
           "name": "Iggy"
         }
       ],
@@ -2588,7 +2588,7 @@ var database_data = {
       "label": "WENDY",
       "blpns": [
         {
-          "blpn": "3068bpb2151",
+          "blpn": "3068pb2151",
           "name": "Wendy"
         }
       ],
@@ -2599,7 +2599,7 @@ var database_data = {
       "label": "MORTON",
       "blpns": [
         {
-          "blpn": "3068bpb2306",
+          "blpn": "3068pb2306",
           "name": "Morton"
         }
       ],
@@ -2621,7 +2621,7 @@ var database_data = {
       "label": "KING BOO",
       "blpns": [
         {
-          "blpn": "3068bpb1388",
+          "blpn": "3068pb1388",
           "name": "King Boo"
         },
         {
@@ -2640,7 +2640,7 @@ var database_data = {
       "label": "KINGBOO2",
       "blpns": [
         {
-          "blpn": "3068bpb1975",
+          "blpn": "3068pb1975",
           "name": "Dark Moon King Boo"
         }
       ],
@@ -2651,7 +2651,7 @@ var database_data = {
       "label": "JrBOWSER",
       "blpns": [
         {
-          "blpn": "3068bpb1378",
+          "blpn": "3068pb1378",
           "name": "Bowser Jr"
         },
         {
@@ -2665,7 +2665,7 @@ var database_data = {
       "label": "BOWSER",
       "blpns": [
         {
-          "blpn": "3068bpb1416",
+          "blpn": "3068pb1416",
           "name": "Bowser"
         }
       ],
@@ -2676,7 +2676,7 @@ var database_data = {
       "label": "BOWSER 2",
       "blpns": [
         {
-          "blpn": "3068bpb2059",
+          "blpn": "3068pb2059",
           "name": "Bowser"
         }
       ],
@@ -2687,7 +2687,7 @@ var database_data = {
       "label": "GOAL",
       "blpns": [
         {
-          "blpn": "3068bpb1379",
+          "blpn": "3068pb1379",
           "name": "Goal"
         },
         {

--- a/mariocodes.json
+++ b/mariocodes.json
@@ -24,7 +24,7 @@
       "label": "START",
       "blpns": [
         {
-          "blpn": "3068bpb1380",
+          "blpn": "3068pb1380",
           "name": "Start (Mario starter set)"
         },
         {
@@ -39,7 +39,7 @@
       "label": "START2",
       "blpns": [
         {
-          "blpn": "3068bpb1802",
+          "blpn": "3068pb1802",
           "name": "Start 60 (Luigi)"
         }
       ],
@@ -50,7 +50,7 @@
       "label": "START3",
       "blpns": [
         {
-          "blpn": "3068bpb2093",
+          "blpn": "3068pb2093",
           "name": "Start 60 (Peach)"
         }
       ],
@@ -61,7 +61,7 @@
       "label": "START 30",
       "blpns": [
         {
-          "blpn": "3068bpb1483",
+          "blpn": "3068pb1483",
           "name": "Start 30"
         }
       ],
@@ -72,7 +72,7 @@
       "label": "STARTC50",
       "blpns": [
         {
-          "blpn": "3068bpb1954",
+          "blpn": "3068pb1954",
           "name": "50-coin Start"
         }
       ],
@@ -83,7 +83,7 @@
       "label": "START 80",
       "blpns": [
         {
-          "blpn": "3068bpb2060",
+          "blpn": "3068pb2060",
           "name": "Peach castle start"
         }
       ]
@@ -93,7 +93,7 @@
       "label": "START 90",
       "blpns": [
         {
-          "blpn": "3068bpb1962",
+          "blpn": "3068pb1962",
           "name": "Cannon Start 90"
         }
       ],
@@ -104,7 +104,7 @@
       "label": "SSTART90",
       "blpns": [
         {
-          "blpn": "3068bpb1972",
+          "blpn": "3068pb1972",
           "name": "Spooky Start 90"
         }
       ],
@@ -115,7 +115,7 @@
       "label": "CHKPOINT",
       "blpns": [
         {
-          "blpn": "3068bpb2153",
+          "blpn": "3068pb2153",
           "name": "Checkpoint flag"
         }
       ],
@@ -187,7 +187,7 @@
       "label": "CAMPFIRE",
       "blpns": [
         {
-          "blpn": "3068bpb2186",
+          "blpn": "3068pb2186",
           "name": "Campfire"
         }
       ]
@@ -197,7 +197,7 @@
       "label": "YOSHI",
       "blpns": [
         {
-          "blpn": "3068bpb1385",
+          "blpn": "3068pb1385",
           "name": "Speech Bubble Yoshi"
         }
       ]
@@ -207,11 +207,11 @@
       "label": "TOAD",
       "blpns": [
         {
-          "blpn": "3068bpb1402",
+          "blpn": "3068pb1402",
           "name": "Speech Bubble Toad"
         },
         {
-          "blpn": "3068bpb2053",
+          "blpn": "3068pb2053",
           "name": "Green, Purple, Blue & Yellow Toad / Toadette Speech Bubble"
         }
       ]
@@ -221,7 +221,7 @@
       "label": "TOADETTE",
       "blpns": [
         {
-          "blpn": "3068bpb1401",
+          "blpn": "3068pb1401",
           "name": "Speech Bubble Toadette"
         }
       ]
@@ -231,7 +231,7 @@
       "label": "TOAD 2",
       "blpns": [
         {
-          "blpn": "3068bpb1957",
+          "blpn": "3068pb1957",
           "name": "Blue Toad"
         }
       ],
@@ -242,7 +242,7 @@
       "label": "PENGUIN",
       "blpns": [
         {
-          "blpn": "3068bpb2333",
+          "blpn": "3068pb2333",
           "name": "Penguin"
         },
         {
@@ -257,7 +257,7 @@
       "label": "DONKEY K",
       "blpns": [
         {
-          "blpn": "3068bpb2291",
+          "blpn": "3068pb2291",
           "name": "Donkey Kong"
         }
       ],
@@ -268,7 +268,7 @@
       "label": "CRANKY K",
       "blpns": [
         {
-          "blpn": "3068bpb2289",
+          "blpn": "3068pb2289",
           "name": "Cranky Kong"
         }
       ],
@@ -279,7 +279,7 @@
       "label": "DIDDY K",
       "blpns": [
         {
-          "blpn": "3068bpb2307",
+          "blpn": "3068pb2307",
           "name": "Diddy Kong"
         }
       ],
@@ -290,7 +290,7 @@
       "label": "FUNKY K",
       "blpns": [
         {
-          "blpn": "3068bpb2310",
+          "blpn": "3068pb2310",
           "name": "Funky Kong"
         }
       ],
@@ -301,7 +301,7 @@
       "label": "DORRIE",
       "blpns": [
         {
-          "blpn": "3068bpb1985",
+          "blpn": "3068pb1985",
           "name": "Dorrie"
         }
       ]
@@ -311,7 +311,7 @@
       "label": "DORRIE2",
       "blpns": [
         {
-          "blpn": "3068bpb2341",
+          "blpn": "3068pb2341",
           "name": "Dorrie the Dolphin"
         },
         {
@@ -326,7 +326,7 @@
       "label": "DOLPHIN",
       "blpns": [
         {
-          "blpn": "3068bpb1979",
+          "blpn": "3068pb1979",
           "name": "Dolphin"
         }
       ],
@@ -348,7 +348,7 @@
       "label": "MINECART",
       "blpns": [
         {
-          "blpn": "3068bpb2311",
+          "blpn": "3068pb2311",
           "name": "Minecart"
         }
       ],
@@ -359,7 +359,7 @@
       "label": "DK RIDE",
       "blpns": [
         {
-          "blpn": "3068bpb2290",
+          "blpn": "3068pb2290",
           "name": "Donkey Kong ride"
         }
       ]
@@ -369,7 +369,7 @@
       "label": "BWSRKART",
       "blpns": [
         {
-          "blpn": "3068bpb2334",
+          "blpn": "3068pb2334",
           "name": "Bowser's Car and Mario Kart music"
         },
         {
@@ -383,7 +383,7 @@
       "label": "BABYOSHI",
       "blpns": [
         {
-          "blpn": "3068bpb2064",
+          "blpn": "3068pb2064",
           "name": "Chubby Baby Yoshi, yellow"
         }
       ]
@@ -403,7 +403,7 @@
       "label": "YOSHIEGG",
       "blpns": [
         {
-          "blpn": "3068bpb1807",
+          "blpn": "3068pb1807",
           "name": "Pink Yoshi egg"
         },
         {
@@ -418,7 +418,7 @@
       "label": "YOSHI E2",
       "blpns": [
         {
-          "blpn": "3068bpb1977",
+          "blpn": "3068pb1977",
           "name": "Yellow Yoshi egg"
         }
       ]
@@ -428,7 +428,7 @@
       "label": "YOSHI E3",
       "blpns": [
         {
-          "blpn": "3068bpb2065",
+          "blpn": "3068pb2065",
           "name": "Red Yoshi egg"
         }
       ]
@@ -438,7 +438,7 @@
       "label": "YOSHI E4",
       "blpns": [
         {
-          "blpn": "3068bpb2072",
+          "blpn": "3068pb2072",
           "name": "Green Yoshi egg"
         }
       ]
@@ -448,7 +448,7 @@
       "label": "YOSHI E5",
       "blpns": [
         {
-          "blpn": "3068bpb2154",
+          "blpn": "3068pb2154",
           "name": "Blue Yoshi egg"
         }
       ]
@@ -458,7 +458,7 @@
       "label": "YOSHIEGG",
       "blpns": [
         {
-          "blpn": "3068bpb2335",
+          "blpn": "3068pb2335",
           "name": "Hatching Yoshi Egg"
         },
         {
@@ -473,7 +473,7 @@
       "label": "POLTER",
       "blpns": [
         {
-          "blpn": "3068bpb1983",
+          "blpn": "3068pb1983",
           "name": "Polterpup"
         }
       ]
@@ -483,7 +483,7 @@
       "label": "GOLDBONE",
       "blpns": [
         {
-          "blpn": "3068bpb1981",
+          "blpn": "3068pb1981",
           "name": "Golden bone"
         }
       ],
@@ -494,7 +494,7 @@
       "label": "EGADD",
       "blpns": [
         {
-          "blpn": "3068bpb1986",
+          "blpn": "3068pb1986",
           "name": "Professor E. Gadd"
         }
       ]
@@ -504,7 +504,7 @@
       "label": "BPENGUIN",
       "blpns": [
         {
-          "blpn": "3068bpb1909",
+          "blpn": "3068pb1909",
           "name": "Baby penguin"
         }
       ]
@@ -514,7 +514,7 @@
       "label": "NABBIT",
       "blpns": [
         {
-          "blpn": "3068bpb2063",
+          "blpn": "3068pb2063",
           "name": "Nabbit"
         }
       ],
@@ -536,7 +536,7 @@
       "label": "1 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1404",
+          "blpn": "3068pb1404",
           "name": "1 Block Treasure"
         }
       ]
@@ -546,7 +546,7 @@
       "label": "2 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1405",
+          "blpn": "3068pb1405",
           "name": "2 Block Treasure"
         }
       ]
@@ -556,7 +556,7 @@
       "label": "3 BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1406",
+          "blpn": "3068pb1406",
           "name": "3 Block Treasure"
         }
       ]
@@ -566,7 +566,7 @@
       "label": "GEM PURP",
       "blpns": [
         {
-          "blpn": "3068bpb1968",
+          "blpn": "3068pb1968",
           "name": "Purple diamond"
         }
       ]
@@ -576,7 +576,7 @@
       "label": "GEM BLUE",
       "blpns": [
         {
-          "blpn": "3068bpb1967",
+          "blpn": "3068pb1967",
           "name": "Blue diamond"
         }
       ]
@@ -586,7 +586,7 @@
       "label": "GEM GREE",
       "blpns": [
         {
-          "blpn": "3068bpb1969",
+          "blpn": "3068pb1969",
           "name": "Green diamond"
         }
       ]
@@ -596,7 +596,7 @@
       "label": "CHEST",
       "blpns": [
         {
-          "blpn": "3068bpb2300",
+          "blpn": "3068pb2300",
           "name": "Locked Chest"
         }
       ],
@@ -607,7 +607,7 @@
       "label": "CHESTKEY",
       "blpns": [
         {
-          "blpn": "3068bpb2301",
+          "blpn": "3068pb2301",
           "name": "Chest Key"
         }
       ]
@@ -617,11 +617,11 @@
       "label": "RED C1",
       "blpns": [
         {
-          "blpn": "3068bpb1485",
+          "blpn": "3068pb1485",
           "name": "Red Coin Block Rounded (green tile)"
         },
         {
-          "blpn": "3068bpb1970",
+          "blpn": "3068pb1970",
           "name": "Red Coin Block Rounded"
         }
       ]
@@ -631,7 +631,7 @@
       "label": "RED C2",
       "blpns": [
         {
-          "blpn": "3068bpb1487",
+          "blpn": "3068pb1487",
           "name": "Red Coin Block Triange (green tile)"
         },
         {
@@ -645,11 +645,11 @@
       "label": "RED C3",
       "blpns": [
         {
-          "blpn": "3068bpb1486",
+          "blpn": "3068pb1486",
           "name": "Red Coin Block Square (green tile)"
         },
         {
-          "blpn": "3068bpb1971",
+          "blpn": "3068pb1971",
           "name": "Red Coin Block Square"
         }
       ]
@@ -659,7 +659,7 @@
       "label": "GOLDGROW",
       "blpns": [
         {
-          "blpn": "3068bpb2071",
+          "blpn": "3068pb2071",
           "name": "Treat Carousel"
         }
       ],
@@ -670,7 +670,7 @@
       "label": "PRESENT",
       "blpns": [
         {
-          "blpn": "3068bpb2095",
+          "blpn": "3068pb2095",
           "name": "Gift box 1"
         }
       ]
@@ -680,7 +680,7 @@
       "label": "PRESENT2",
       "blpns": [
         {
-          "blpn": "3068bpb2070",
+          "blpn": "3068pb2070",
           "name": "Gift box 2"
         }
       ],
@@ -691,7 +691,7 @@
       "label": "PRESENT3",
       "blpns": [
         {
-          "blpn": "3068bpb2152",
+          "blpn": "3068pb2152",
           "name": "Gift box 3"
         }
       ],
@@ -713,7 +713,7 @@
       "label": "TURNIP",
       "blpns": [
         {
-          "blpn": "3068bpb2149",
+          "blpn": "3068pb2149",
           "name": "Turnip"
         }
       ],
@@ -790,7 +790,7 @@
       "label": "PICNIC",
       "blpns": [
         {
-          "blpn": "3068bpb2284",
+          "blpn": "3068pb2284",
           "name": "Picnic Basket"
         }
       ],
@@ -801,7 +801,7 @@
       "label": "PICNIC2",
       "blpns": [
         {
-          "blpn": "3068bpb2313",
+          "blpn": "3068pb2313",
           "name": "Picnic basket 2"
         },
         {
@@ -848,7 +848,7 @@
       "label": "POW",
       "blpns": [
         {
-          "blpn": "3068bpb1361",
+          "blpn": "3068pb1361",
           "name": "POW"
         }
       ]
@@ -868,7 +868,7 @@
       "label": "STAR",
       "blpns": [
         {
-          "blpn": "3068bpb1384",
+          "blpn": "3068pb1384",
           "name": "Star"
         }
       ]
@@ -878,7 +878,7 @@
       "label": "TIMER",
       "blpns": [
         {
-          "blpn": "3068bpb1347",
+          "blpn": "3068pb1347",
           "name": "Timer"
         }
       ],
@@ -889,7 +889,7 @@
       "label": "TIMER 2",
       "blpns": [
         {
-          "blpn": "3068bpb1855",
+          "blpn": "3068pb1855",
           "name": "Timer 2"
         }
       ],
@@ -900,7 +900,7 @@
       "label": "TIMER 3",
       "blpns": [
         {
-          "blpn": "3068bpb2083",
+          "blpn": "3068pb2083",
           "name": "Timer 3"
         }
       ],
@@ -911,7 +911,7 @@
       "label": "? BLOCK",
       "blpns": [
         {
-          "blpn": "3068bpb1359",
+          "blpn": "3068pb1359",
           "name": "Mystery Block ?"
         }
       ]
@@ -921,7 +921,7 @@
       "label": "P?BLOCK1",
       "blpns": [
         {
-          "blpn": "3068bpb1762",
+          "blpn": "3068pb1762",
           "name": "Customization Mystery Block 1"
         }
       ],
@@ -933,7 +933,7 @@
       "label": "P?BLOCK2",
       "blpns": [
         {
-          "blpn": "3068bpb1784",
+          "blpn": "3068pb1784",
           "name": "Customization Mystery Block 2"
         }
       ],
@@ -945,7 +945,7 @@
       "label": "TIMEGEAR",
       "blpns": [
         {
-          "blpn": "3068bpb1533",
+          "blpn": "3068pb1533",
           "name": "Customization Time Block"
         }
       ],
@@ -956,7 +956,7 @@
       "label": "P SWITCH",
       "blpns": [
         {
-          "blpn": "3068bpb1394",
+          "blpn": "3068pb1394",
           "name": "P Switch"
         }
       ]
@@ -966,7 +966,7 @@
       "label": "COIN 1",
       "blpns": [
         {
-          "blpn": "3068bpb1387",
+          "blpn": "3068pb1387",
           "name": "Coin"
         },
         {
@@ -980,7 +980,7 @@
       "label": "COIN 2",
       "blpns": [
         {
-          "blpn": "3068bpb1393",
+          "blpn": "3068pb1393",
           "name": "Coin 2"
         }
       ]
@@ -990,11 +990,11 @@
       "label": "COIN 3",
       "blpns": [
         {
-          "blpn": "3068bpb1527",
+          "blpn": "3068pb1527",
           "name": "Coin 3"
         },
         {
-          "blpn": "3068bpb2079",
+          "blpn": "3068pb2079",
           "name": "Coin 3"
         }
       ]
@@ -1072,7 +1072,7 @@
           "name": "Peepa"
         },
         {
-          "blpn": "3068bpb1409",
+          "blpn": "3068pb1409",
           "name": "Boo"
         }
       ],
@@ -1083,7 +1083,7 @@
       "label": "BOO",
       "blpns": [
         {
-          "blpn": "3068bpb1799",
+          "blpn": "3068pb1799",
           "name": "Boo"
         }
       ]
@@ -1093,7 +1093,7 @@
       "label": "GRBG GHO",
       "blpns": [
         {
-          "blpn": "3068bpb1973",
+          "blpn": "3068pb1973",
           "name": "Garbage can ghost"
         }
       ],
@@ -1104,7 +1104,7 @@
       "label": "GRBGHOST",
       "blpns": [
         {
-          "blpn": "3068bpb1974",
+          "blpn": "3068pb1974",
           "name": "Grabbing ghost"
         }
       ],
@@ -1126,7 +1126,7 @@
       "label": "BOGMIRE",
       "blpns": [
         {
-          "blpn": "3068bpb1984",
+          "blpn": "3068pb1984",
           "name": "Bogmire"
         }
       ],
@@ -1151,23 +1151,23 @@
       "label": "GOOMBA",
       "blpns": [
         {
-          "blpn": "3068bpb1381",
+          "blpn": "3068pb1381",
           "name": "Goomba"
         },
         {
-          "blpn": "3068bpb1505",
+          "blpn": "3068pb1505",
           "name": "Bone Goomba"
         },
         {
-          "blpn": "3068bpb1501",
+          "blpn": "3068pb1501",
           "name": "Ninji"
         },
         {
-          "blpn": "3068bpb1348",
+          "blpn": "3068pb1348",
           "name": "Bullet Bill"
         },
         {
-          "blpn": "3068bpb1360",
+          "blpn": "3068pb1360",
           "name": "Monty Mole"
         },
         {
@@ -1175,31 +1175,31 @@
           "name": "Fly Guy"
         },
         {
-          "blpn": "3068bpb1365",
+          "blpn": "3068pb1365",
           "name": "Fuzzy"
         },
         {
-          "blpn": "3068bpb1520",
+          "blpn": "3068pb1520",
           "name": "Foo"
         },
         {
-          "blpn": "3068bpb1904",
+          "blpn": "3068pb1904",
           "name": "Crowber"
         },
         {
-          "blpn": "3068bpb1915",
+          "blpn": "3068pb1915",
           "name": "Para-Biddybud"
         },
         {
-          "blpn": "3068bpb1499",
+          "blpn": "3068pb1499",
           "name": "Parachute Goomba"
         },
         {
-          "blpn": "3068bpb1916",
+          "blpn": "3068pb1916",
           "name": "Scaredy Rat"
         },
         {
-          "blpn": "3068bpb2096",
+          "blpn": "3068pb2096",
           "name": "Cat Goomba"
         },
         {
@@ -1207,35 +1207,35 @@
           "name": "Shy Guy"
         },
         {
-          "blpn": "3068bpb2054",
+          "blpn": "3068pb2054",
           "name": "Toady"
         },
         {
-          "blpn": "3068bpb1798",
+          "blpn": "3068pb1798",
           "name": "Swoop"
         },
         {
-          "blpn": "3068bpb1932",
+          "blpn": "3068pb1932",
           "name": "Stingby"
         },
         {
-          "blpn": "3068bpb1905",
+          "blpn": "3068pb1905",
           "name": "Galoomba"
         },
         {
-          "blpn": "3068bpb1888",
+          "blpn": "3068pb1888",
           "name": "Goombrat"
         },
         {
-          "blpn": "3068bpb1908",
+          "blpn": "3068pb1908",
           "name": "Ant Trooper"
         },
         {
-          "blpn": "3068bpb2062",
+          "blpn": "3068pb2062",
           "name": "Waddlewing"
         },
         {
-          "blpn": "3068bpb1797",
+          "blpn": "3068pb1797",
           "name": "Scuttlebug"
         },
         {
@@ -1249,7 +1249,7 @@
       "label": "THWIMP",
       "blpns": [
         {
-          "blpn": "3068bpb1524",
+          "blpn": "3068pb1524",
           "name": "Thwimp"
         }
       ]
@@ -1259,7 +1259,7 @@
       "label": "BRAMBALL",
       "blpns": [
         {
-          "blpn": "3068bpb1526",
+          "blpn": "3068pb1526",
           "name": "Bramball"
         }
       ]
@@ -1269,31 +1269,31 @@
       "label": "BLOOPER",
       "blpns": [
         {
-          "blpn": "3068bpb1363",
+          "blpn": "3068pb1363",
           "name": "Blooper"
         },
         {
-          "blpn": "3068bpb1413",
+          "blpn": "3068pb1413",
           "name": "Urchin"
         },
         {
-          "blpn": "3068bpb1403",
+          "blpn": "3068pb1403",
           "name": "Cheep Cheep"
         },
         {
-          "blpn": "3068bpb1349",
+          "blpn": "3068pb1349",
           "name": "Eep Cheep"
         },
         {
-          "blpn": "3068bpb1500",
+          "blpn": "3068pb1500",
           "name": "Huckit Crab"
         },
         {
-          "blpn": "3068bpb1521",
+          "blpn": "3068pb1521",
           "name": "Spiny Cheep Cheep"
         },
         {
-          "blpn": "3068bpb1796",
+          "blpn": "3068pb1796",
           "name": "Torpedo Ted"
         }
       ]
@@ -1303,23 +1303,23 @@
       "label": "BUZZY",
       "blpns": [
         {
-          "blpn": "3068bpb1519",
+          "blpn": "3068pb1519",
           "name": "Para-Beetle"
         },
         {
-          "blpn": "3068bpb1415",
+          "blpn": "3068pb1415",
           "name": "Buzzy Beetle"
         },
         {
-          "blpn": "3068bpb1364",
+          "blpn": "3068pb1364",
           "name": "Spiny"
         },
         {
-          "blpn": "3068bpb1964",
+          "blpn": "3068pb1964",
           "name": "Mechakoopa"
         },
         {
-          "blpn": "3068bpb1907",
+          "blpn": "3068pb1907",
           "name": "Bony Beetle"
         },
         {
@@ -1343,15 +1343,15 @@
       "label": "DRY BONE",
       "blpns": [
         {
-          "blpn": "3068bpb1408",
+          "blpn": "3068pb1408",
           "name": "Dry Bones"
         },
         {
-          "blpn": "3068bpb1414",
+          "blpn": "3068pb1414",
           "name": "Paragoomba"
         },
         {
-          "blpn": "3068bpb1397",
+          "blpn": "3068pb1397",
           "name": "Lava Bubble"
         },
         {
@@ -1365,7 +1365,7 @@
       "label": "AMP",
       "blpns": [
         {
-          "blpn": "3068bpb1801",
+          "blpn": "3068pb1801",
           "name": "Amp"
         }
       ],
@@ -1376,7 +1376,7 @@
       "label": "FREEZIE",
       "blpns": [
         {
-          "blpn": "3068bpb1914",
+          "blpn": "3068pb1914",
           "name": "Freezie"
         }
       ],
@@ -1387,7 +1387,7 @@
       "label": "WHOMP",
       "blpns": [
         {
-          "blpn": "3068bpb1396",
+          "blpn": "3068pb1396",
           "name": "Whomp"
         }
       ],
@@ -1398,7 +1398,7 @@
       "label": "LAVA",
       "blpns": [
         {
-          "blpn": "3068bpb1410",
+          "blpn": "3068pb1410",
           "name": "Lava Bubble"
         },
         {
@@ -1412,7 +1412,7 @@
       "label": "THWOMP",
       "blpns": [
         {
-          "blpn": "3068bpb1407",
+          "blpn": "3068pb1407",
           "name": "Thwomp"
         },
         {
@@ -1426,7 +1426,7 @@
       "label": "BOB-OMB",
       "blpns": [
         {
-          "blpn": "3068bpb1476",
+          "blpn": "3068pb1476",
           "name": "Bob-Omb 1"
         }
       ]
@@ -1436,7 +1436,7 @@
       "label": "BOMB 2",
       "blpns": [
         {
-          "blpn": "3068bpb1366",
+          "blpn": "3068pb1366",
           "name": "Bob-Omb 2"
         }
       ]
@@ -1446,7 +1446,7 @@
       "label": "BOMB 3",
       "blpns": [
         {
-          "blpn": "3068bpb1883",
+          "blpn": "3068pb1883",
           "name": "Bob-omb"
         },
         {
@@ -1460,7 +1460,7 @@
       "label": "PARABOMB",
       "blpns": [
         {
-          "blpn": "3068bpb1795",
+          "blpn": "3068pb1795",
           "name": "Parachute Bob-omb"
         }
       ]
@@ -1470,11 +1470,11 @@
       "label": "PIRANHA",
       "blpns": [
         {
-          "blpn": "3068bpb1382",
+          "blpn": "3068pb1382",
           "name": "Piranha Plant"
         },
         {
-          "blpn": "3068bpb2299",
+          "blpn": "3068pb2299",
           "name": "Bone Piranha Plant"
         },
         {
@@ -1488,7 +1488,7 @@
       "label": "KOOPA 1",
       "blpns": [
         {
-          "blpn": "3068bpb1383",
+          "blpn": "3068pb1383",
           "name": "Koopa Troopa"
         }
       ]
@@ -1498,7 +1498,7 @@
       "label": "KOOPA 2",
       "blpns": [
         {
-          "blpn": "3068bpb1351",
+          "blpn": "3068pb1351",
           "name": "Koopa Troopa 2"
         }
       ]
@@ -1508,7 +1508,7 @@
       "label": "KPARAT 1",
       "blpns": [
         {
-          "blpn": "3068bpb1477",
+          "blpn": "3068pb1477",
           "name": "Koopa Paratroopa"
         }
       ]
@@ -1518,7 +1518,7 @@
       "label": "KPARAT 2",
       "blpns": [
         {
-          "blpn": "3068bpb1478",
+          "blpn": "3068pb1478",
           "name": "Koopa Paratroopa 2"
         }
       ]
@@ -1528,7 +1528,7 @@
       "label": "EXPLODE",
       "blpns": [
         {
-          "blpn": "3068bpb1386",
+          "blpn": "3068pb1386",
           "name": "Swoop Explosion"
         }
       ]
@@ -1549,7 +1549,7 @@
       "label": "STONE",
       "blpns": [
         {
-          "blpn": "3068bpb1362",
+          "blpn": "3068pb1362",
           "name": "Stone Eye"
         }
       ]
@@ -1559,7 +1559,7 @@
       "label": "POKEY",
       "blpns": [
         {
-          "blpn": "3068bpb1369",
+          "blpn": "3068pb1369",
           "name": "Pokey"
         }
       ],
@@ -1570,7 +1570,7 @@
       "label": "BIG URCH",
       "blpns": [
         {
-          "blpn": "3068bpb1978",
+          "blpn": "3068pb1978",
           "name": "Purple Urchin"
         }
       ],
@@ -1581,7 +1581,7 @@
       "label": "BULLY",
       "blpns": [
         {
-          "blpn": "3068bpb1910",
+          "blpn": "3068pb1910",
           "name": "Bully"
         }
       ],
@@ -1592,7 +1592,7 @@
       "label": "CONKDOR",
       "blpns": [
         {
-          "blpn": "3068bpb2125",
+          "blpn": "3068pb2125",
           "name": "Conkdor"
         }
       ],
@@ -1603,7 +1603,7 @@
       "label": "LAKITU",
       "blpns": [
         {
-          "blpn": "3068bpb1856",
+          "blpn": "3068pb1856",
           "name": "Lakitu"
         },
         {
@@ -1618,7 +1618,7 @@
       "label": "ROCKY",
       "blpns": [
         {
-          "blpn": "3068bpb1959",
+          "blpn": "3068pb1959",
           "name": "Rocky Wrench"
         }
       ],
@@ -1629,7 +1629,7 @@
       "label": "COINCOFF",
       "blpns": [
         {
-          "blpn": "3068bpb1911",
+          "blpn": "3068pb1911",
           "name": "Coin Coffer"
         }
       ],
@@ -1640,11 +1640,11 @@
       "label": "GRRROL",
       "blpns": [
         {
-          "blpn": "3068bpb1955",
+          "blpn": "3068pb1955",
           "name": "Grrrol"
         },
         {
-          "blpn": "3068bpb2075",
+          "blpn": "3068pb2075",
           "name": "Piranha Plant"
         }
       ],
@@ -1655,7 +1655,7 @@
       "label": "BIG GOOM",
       "blpns": [
         {
-          "blpn": "3068bpb2076",
+          "blpn": "3068pb2076",
           "name": "Big Goomba"
         }
       ],
@@ -1666,7 +1666,7 @@
       "label": "BIGKOOPA",
       "blpns": [
         {
-          "blpn": "3068bpb2078",
+          "blpn": "3068pb2078",
           "name": "Big Koopa"
         }
       ],
@@ -1677,7 +1677,7 @@
       "label": "FLIPRUS",
       "blpns": [
         {
-          "blpn": "3068bpb2185",
+          "blpn": "3068pb2185",
           "name": "Fliprus"
         }
       ],
@@ -1688,7 +1688,7 @@
       "label": "BOOMRBRO",
       "blpns": [
         {
-          "blpn": "3068bpb2073",
+          "blpn": "3068pb2073",
           "name": "Boomerang Bro"
         }
       ],
@@ -1699,15 +1699,15 @@
       "label": "HAMMRBRO",
       "blpns": [
         {
-          "blpn": "3068bpb2055",
+          "blpn": "3068pb2055",
           "name": "Hammer Bro"
         },
         {
-          "blpn": "3068bpb2177",
+          "blpn": "3068pb2177",
           "name": "Ice Bro"
         },
         {
-          "blpn": "3068bpb2159",
+          "blpn": "3068pb2159",
           "name": "Fire Bro"
         }
       ],
@@ -1729,7 +1729,7 @@
       "label": "BIGSPIKE",
       "blpns": [
         {
-          "blpn": "3068bpb2074",
+          "blpn": "3068pb2074",
           "name": "Big Spike"
         }
       ],
@@ -1740,7 +1740,7 @@
       "label": "SMOLSUMO",
       "blpns": [
         {
-          "blpn": "3068bpb2176",
+          "blpn": "3068pb2176",
           "name": "Sumo Bro"
         }
       ],
@@ -1751,7 +1751,7 @@
       "label": "REZNOR 1",
       "blpns": [
         {
-          "blpn": "3068bpb1885",
+          "blpn": "3068pb1885",
           "name": "Reznor (With fireball)"
         }
       ],
@@ -1762,7 +1762,7 @@
       "label": "REZNOR 2",
       "blpns": [
         {
-          "blpn": "3068bpb1884",
+          "blpn": "3068pb1884",
           "name": "Reznor (No fireball)"
         }
       ],
@@ -1773,7 +1773,7 @@
       "label": "SUMO",
       "blpns": [
         {
-          "blpn": "3068bpb1844",
+          "blpn": "3068pb1844",
           "name": "Boss Sumo"
         }
       ],
@@ -1784,7 +1784,7 @@
       "label": "BOOMBOOM",
       "blpns": [
         {
-          "blpn": "3068bpb1814",
+          "blpn": "3068pb1814",
           "name": "Boom-boom"
         }
       ],
@@ -1795,7 +1795,7 @@
       "label": "NES",
       "blpns": [
         {
-          "blpn": "3068bpb1390",
+          "blpn": "3068pb1390",
           "name": "TV"
         }
       ],
@@ -1819,7 +1819,7 @@
       "label": "BIGBOWSR",
       "blpns": [
         {
-          "blpn": "3068bpb2113",
+          "blpn": "3068pb2113",
           "name": "Mighty Bowser"
         }
       ],
@@ -1830,7 +1830,7 @@
       "label": "HAMMER",
       "blpns": [
         {
-          "blpn": "3068bpb1370",
+          "blpn": "3068pb1370",
           "name": "Hammer Turntable"
         }
       ]
@@ -1896,7 +1896,7 @@
       "label": "SPIN 6",
       "blpns": [
         {
-          "blpn": "3068bpb1966",
+          "blpn": "3068pb1966",
           "name": "Spin 6"
         }
       ],
@@ -1911,7 +1911,7 @@
           "name": "Side-to-side Waggle Arrows"
         },
         {
-          "blpn": "3068bpb2067",
+          "blpn": "3068pb2067",
           "name": "Biased Directional Arrows"
         }
       ],
@@ -1933,7 +1933,7 @@
       "label": "SPINY",
       "blpns": [
         {
-          "blpn": "3068bpb1484",
+          "blpn": "3068pb1484",
           "name": "Spiny 2"
         }
       ]
@@ -1969,7 +1969,7 @@
       "label": "BDARR 2",
       "blpns": [
         {
-          "blpn": "3068bpb1350",
+          "blpn": "3068pb1350",
           "name": "Bidirectional Arrows 2"
         }
       ],
@@ -1980,7 +1980,7 @@
       "label": "BDARR 3",
       "blpns": [
         {
-          "blpn": "3068bpb1502",
+          "blpn": "3068pb1502",
           "name": "Bidirectional Arrows 3"
         }
       ],
@@ -2017,7 +2017,7 @@
       "label": "LAVALIFT",
       "blpns": [
         {
-          "blpn": "3068bpb2160",
+          "blpn": "3068pb2160",
           "name": "Curved Bidirectional Arrows (Lava Lift)"
         }
       ],
@@ -2028,7 +2028,7 @@
       "label": "KEYHOLE",
       "blpns": [
         {
-          "blpn": "3068bpb1982",
+          "blpn": "3068pb1982",
           "name": "Entrance keyhole"
         }
       ],
@@ -2069,7 +2069,7 @@
       "label": "GEAR",
       "blpns": [
         {
-          "blpn": "3068bpb1803",
+          "blpn": "3068pb1803",
           "name": "Gear icon"
         }
       ],
@@ -2080,7 +2080,7 @@
       "label": "NUT",
       "blpns": [
         {
-          "blpn": "3068bpb1804",
+          "blpn": "3068pb1804",
           "name": "Nut icon"
         }
       ],
@@ -2113,7 +2113,7 @@
       "label": "SWING",
       "blpns": [
         {
-          "blpn": "3068bpb2094",
+          "blpn": "3068pb2094",
           "name": "Peach swing"
         }
       ],
@@ -2124,7 +2124,7 @@
       "label": "BIASDIR",
       "blpns": [
         {
-          "blpn": "3068bpb1853",
+          "blpn": "3068pb1853",
           "name": "Biased directional Arrows"
         },
         {
@@ -2138,7 +2138,7 @@
       "label": "STEERING",
       "blpns": [
         {
-          "blpn": "3068bpb1958",
+          "blpn": "3068pb1958",
           "name": "Steering wheel for Bowser, Larry, and Morton's ships.  Tip to fire cannon. Miltiplayer fire at each other."
         }
       ],
@@ -2175,7 +2175,7 @@
       "label": "DIVING",
       "blpns": [
         {
-          "blpn": "3068bpb1980",
+          "blpn": "3068pb1980",
           "name": "Diving board"
         }
       ],
@@ -2186,7 +2186,7 @@
       "label": "SNAGGLES",
       "blpns": [
         {
-          "blpn": "3068bpb2309",
+          "blpn": "3068pb2309",
           "name": "Snaggles the shark"
         }
       ],
@@ -2197,7 +2197,7 @@
       "label": "CHECHOMP",
       "blpns": [
         {
-          "blpn": "3068bpb2340",
+          "blpn": "3068pb2340",
           "name": "Cheep Chomp"
         },
         {
@@ -2212,7 +2212,7 @@
       "label": "EXERCISE",
       "blpns": [
         {
-          "blpn": "3068bpb2304",
+          "blpn": "3068pb2304",
           "name": "Barbells"
         }
       ],
@@ -2223,7 +2223,7 @@
       "label": "PCTHRONE",
       "blpns": [
         {
-          "blpn": "3068bpb2066",
+          "blpn": "3068pb2066",
           "name": "Peach throne"
         },
         {
@@ -2238,7 +2238,7 @@
       "label": "BROOM",
       "blpns": [
         {
-          "blpn": "3068bpb1961",
+          "blpn": "3068pb1961",
           "name": "Kamek Broom"
         }
       ],
@@ -2249,7 +2249,7 @@
       "label": "CLOWN",
       "blpns": [
         {
-          "blpn": "3068bpb1918",
+          "blpn": "3068pb1918",
           "name": "Bowser Jr's Clown Car"
         }
       ],
@@ -2260,7 +2260,7 @@
       "label": "SHOE",
       "blpns": [
         {
-          "blpn": "3068bpb2084",
+          "blpn": "3068pb2084",
           "name": "Kuribo's shoe"
         }
       ],
@@ -2282,7 +2282,7 @@
       "label": "BALLOON",
       "blpns": [
         {
-          "blpn": "3068bpb2150",
+          "blpn": "3068pb2150",
           "name": "Peach's Balloon Ride"
         }
       ]
@@ -2312,7 +2312,7 @@
       "label": "RAMBI",
       "blpns": [
         {
-          "blpn": "3068bpb2305",
+          "blpn": "3068pb2305",
           "name": "Rambi the Rhino"
         }
       ],
@@ -2323,7 +2323,7 @@
       "label": "PLANE",
       "blpns": [
         {
-          "blpn": "3068bpb2308",
+          "blpn": "3068pb2308",
           "name": "Airplane"
         }
       ],
@@ -2345,7 +2345,7 @@
       "label": "MUSIC",
       "blpns": [
         {
-          "blpn": "3068bpb2296",
+          "blpn": "3068pb2296",
           "name": "Donkey Kong dancing"
         }
       ],
@@ -2356,7 +2356,7 @@
       "label": "BONGOS",
       "blpns": [
         {
-          "blpn": "3068bpb2292",
+          "blpn": "3068pb2292",
           "name": "Bongo music"
         }
       ],
@@ -2389,7 +2389,7 @@
       "label": "BIRDO",
       "blpns": [
         {
-          "blpn": "3068bpb2178",
+          "blpn": "3068pb2178",
           "name": "Birdo egg"
         }
       ],
@@ -2400,7 +2400,7 @@
       "label": "MAST",
       "blpns": [
         {
-          "blpn": "3068bpb1960",
+          "blpn": "3068pb1960",
           "name": "Bowser ship mast"
         }
       ],
@@ -2433,7 +2433,7 @@
       "label": "LARRY",
       "blpns": [
         {
-          "blpn": "3068bpb1534",
+          "blpn": "3068pb1534",
           "name": "Larry"
         }
       ],
@@ -2444,7 +2444,7 @@
       "label": "LUDWIG",
       "blpns": [
         {
-          "blpn": "3068bpb2058",
+          "blpn": "3068pb2058",
           "name": "Ludwig von Koopa"
         }
       ],
@@ -2466,7 +2466,7 @@
       "label": "IGGY",
       "blpns": [
         {
-          "blpn": "3068bpb2077",
+          "blpn": "3068pb2077",
           "name": "Iggy"
         }
       ],
@@ -2477,7 +2477,7 @@
       "label": "WENDY",
       "blpns": [
         {
-          "blpn": "3068bpb2151",
+          "blpn": "3068pb2151",
           "name": "Wendy"
         }
       ],
@@ -2488,7 +2488,7 @@
       "label": "MORTON",
       "blpns": [
         {
-          "blpn": "3068bpb2306",
+          "blpn": "3068pb2306",
           "name": "Morton"
         }
       ],
@@ -2510,7 +2510,7 @@
       "label": "KING BOO",
       "blpns": [
         {
-          "blpn": "3068bpb1388",
+          "blpn": "3068pb1388",
           "name": "King Boo"
         },
         {
@@ -2529,7 +2529,7 @@
       "label": "KINGBOO2",
       "blpns": [
         {
-          "blpn": "3068bpb1975",
+          "blpn": "3068pb1975",
           "name": "Dark Moon King Boo"
         }
       ],
@@ -2540,7 +2540,7 @@
       "label": "JrBOWSER",
       "blpns": [
         {
-          "blpn": "3068bpb1378",
+          "blpn": "3068pb1378",
           "name": "Bowser Jr"
         },
         {
@@ -2554,7 +2554,7 @@
       "label": "BOWSER",
       "blpns": [
         {
-          "blpn": "3068bpb1416",
+          "blpn": "3068pb1416",
           "name": "Bowser"
         }
       ],
@@ -2565,7 +2565,7 @@
       "label": "BOWSER 2",
       "blpns": [
         {
-          "blpn": "3068bpb2059",
+          "blpn": "3068pb2059",
           "name": "Bowser"
         }
       ],
@@ -2576,7 +2576,7 @@
       "label": "GOAL",
       "blpns": [
         {
-          "blpn": "3068bpb1379",
+          "blpn": "3068pb1379",
           "name": "Goal"
         },
         {


### PR DESCRIPTION
The blpns should just have "pb" not "bpb" (that might be a recent change, as I know these links *used* to work).